### PR TITLE
Fix #19: Add an "Edit on GitHub button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -199,3 +199,24 @@ footer #copyright {
     margin-top: 100px;
     text-align: center;
 }
+
+aside a {
+    position: fixed;
+    right: 10px;
+    bottom: 10px;
+    background-color: white;
+    color: #5682A3;
+    border: 1px solid #5682A3;
+    text-align: center;
+    padding: 10px;
+    border-radius: 2px;
+    font-size: 0.8rem;
+    transition: color .3s, background-color .3s, box-shadow .3s;
+}
+
+aside a:hover {
+    text-decoration: none;
+    background-color: #5682A3;
+    color: white;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+}

--- a/index.html
+++ b/index.html
@@ -162,5 +162,12 @@
         </p>
       </div>
     </footer>
+
+    <aside class="hidden-xs hidden-sm">
+      <a href="https://github.com/w3c/developer-tools/edit/gh-pages/index.html">
+        <span class="glyphicon glyphicon-pencil"></span>
+        Edit on GitHub
+      </a>
+    </aside>
   </body>
 </html>


### PR DESCRIPTION
The button will appear minusculous (yes I made up that word) until #25 is merged, as it also adds a `<html>`-wide font size.

Note for later: replace the pencil icon with a GitHub icon when you switch to another font icon library.
