### PR TITLE
Remove protocol from URLs of three CSS and one image to avoid mixed content warnings

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -4,7 +4,7 @@
         <title>Donate to the W3C developers community</title>
         <meta charset='utf-8'>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
         <link rel="stylesheet" href="octicons/octicons.css">
         <link rel="stylesheet" type="text/css" href="css/style.css">

--- a/faq.html
+++ b/faq.html
@@ -4,7 +4,7 @@
         <title>Frequently Asked Questions - W3C Developers</title>
         <meta charset='utf-8'>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
         <link rel="stylesheet" href="octicons/octicons.css">
         <link rel="stylesheet" type="text/css" href="css/style.css">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>W3C Developers</title>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="octicons/octicons.css">
     <link rel="stylesheet" type="text/css" href="css/style.css">
@@ -206,7 +206,7 @@
                 </div>
                 <div class="tool row col-md-5">
                     <div class="tool-logo">
-                        <img border="0" src="http://www.w3.org/RDF/icons/rdf_flyer.64"
+                        <img border="0" src="//www.w3.org/RDF/icons/rdf_flyer.64"
 alt="RDF Resource Description Framework Flyer Icon" height="40">
                     </div>
                     <div class="tool-content">


### PR DESCRIPTION
&hellip;when visiting the page over HTTPS.

I also suggest editing the URL displayed at the top of [the main page of the project](https://github.com/w3c/developers) to use HTTPS instead.
